### PR TITLE
Ln changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *inventory*.txt
+ansible.cfg
 /playbooks/roles

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*inventory*.txt
+/playbooks/roles

--- a/playbooks/db.yaml
+++ b/playbooks/db.yaml
@@ -1,20 +1,21 @@
 ---
 - hosts: all
   tasks:
-    - name: Set agent type for Linux
-      set_fact:
-        agent_type: db
-      when: ansible_os_family == 'RedHat' or  ansible_os_family == 'Debian'
-
-    - name: Set agent type for Windows
-      set_fact:
-        agent_type: db-win
-      when: ansible_os_family == 'Windows'
+    # - name: Set agent type for Linux
+    #   set_fact:
+    #     agent_type: db
+    #   when: ansible_os_family == 'RedHat' or  ansible_os_family == 'Debian'
+    #
+    # - name: Set agent type for Windows
+    #   set_fact:
+    #     agent_type: db-win
+    #   when: ansible_os_family == 'Windows'
 
     - include_vars: vars/controller.yaml
     - include_role:
         name: appdynamics.agents.db
       vars:
+        agent_type: db
         agent_version: 20.9.0
         db_agent_name: "ProdDBAgent"
-        install_jre: true # set to false if the target machine already contains a JRE
+        install_jre: false # set to false if the target machine already contains a JRE

--- a/playbooks/db.yaml
+++ b/playbooks/db.yaml
@@ -1,11 +1,20 @@
 ---
 - hosts: all
   tasks:
+    - name: Set agent type for Linux
+      set_fact:
+        agent_type: db
+      when: ansible_os_family == 'RedHat' or  ansible_os_family == 'Debian'
+
+    - name: Set agent type for Windows
+      set_fact:
+        agent_type: db-win
+      when: ansible_os_family == 'Windows'
+
     - include_vars: vars/controller.yaml
     - include_role:
         name: appdynamics.agents.db
       vars:
         agent_version: 20.9.0
-        agent_type: db
         db_agent_name: "ProdDBAgent"
         install_jre: true # set to false if the target machine already contains a JRE

--- a/playbooks/db.yaml
+++ b/playbooks/db.yaml
@@ -1,14 +1,11 @@
 ---
-- hosts: linux
+- hosts: all
   tasks:
+    - include_vars: vars/controller.yaml
     - include_role:
         name: appdynamics.agents.db
       vars:
         agent_version: 20.9.0
         agent_type: db
-        controller_account_access_key: "b0248ceb-c954-4a37-97b5-207e90418cb4" # Please add this to your Vault 
-        controller_host_name: "ansible-20100nosshcont-bum4wzwa.appd-cx.com" # Your AppDynamics controller 
-        controller_account_name: "customer1" # Please add this to your Vault 
-        enable_ssl: "false"
-        controller_port: "8090"
-        db_agent_name: "ProdDBAgent" 
+        db_agent_name: "ProdDBAgent"
+        install_jre: true # set to false if the target machine already contains a JRE

--- a/playbooks/install-roles.yml
+++ b/playbooks/install-roles.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  tasks:
+    - file:
+        path:  ../playbooks/roles
+        state: absent
+
+    - local_action:
+        command ansible-galaxy install -r ../requirements.yml --roles-path ../playbooks/roles
+
+    - lineinfile:
+        dest:   ../.gitignore
+        regexp: '^\/roles$'
+        line:   '/playbooks/roles'
+        state:  present

--- a/playbooks/java.yaml
+++ b/playbooks/java.yaml
@@ -8,6 +8,14 @@
         # Define Agent Type and Version
         agent_version: 20.9.0
         agent_type: sun-java
+
+        # Specify a global APM user here, or define a server specific one associated
+        # with the specific host (in the inventory file or a dedicated vars file )
+        # if the apm_user is set here, it will apply to all the hosts
+        # if left blank, it will default to root
+        # NOTE: the user must already exist on the host
+        apm_user: '{{appdynamics_user}}' # <--- Specify the user to install the java agent for.
+
         # The applicationName
         application_name: "IoT_API" # ONLY required if agent type is not machine or db
         tier_name: "java_tier" # ONLY required if agent type is not machine or db

--- a/playbooks/java.yaml
+++ b/playbooks/java.yaml
@@ -1,19 +1,13 @@
 ---
 - hosts: all
   tasks:
+    - include_vars: vars/controller.yaml
     - include_role:
         name: appdynamics.agents.java
       vars:
-        # Define Agent Type and Version 
+        # Define Agent Type and Version
         agent_version: 20.9.0
         agent_type: sun-java
         # The applicationName
         application_name: "IoT_API" # ONLY required if agent type is not machine or db
         tier_name: "java_tier" # ONLY required if agent type is not machine or db
-        # Your controller details 
-        controller_account_access_key: "b0248ceb-c954-4a37-97b5-207e90418cb4" # Please add this to your Vault 
-        controller_host_name: "ansible-20100nosshcont-bum4wzwa.appd-cx.com" # Your AppDynamics controller 
-        controller_account_name: "customer1" # Please add this to your Vault 
-        enable_ssl: "false"
-        controller_port: "8090"
-    

--- a/playbooks/machine-win.yaml
+++ b/playbooks/machine-win.yaml
@@ -1,20 +1,21 @@
 ---
 - hosts: windows
   tasks:
+    - include_vars: vars/controller.yaml
     - include_role:
         name: appdynamics.agents.machine
       vars:
-        # Define Agent Type and Version 
+        # Define Agent Type and Version
         agent_version: 20.9.0
         agent_type: machine-win # Use machine-win for Windows host
-        # Your controller details 
-        controller_account_access_key: "b0248ceb-c954-4a37-97b5-207e90418cb4" # Please add this to your Vault
-        controller_global_analytics_account_name: "customer1_e2f90621-ab21-4bf4-908c-872d213c7f64" # Please add this to your Vault
-        controller_host_name: "ansible-20100nosshcont-bum4wzwa.appd-cx.com" # Your AppDynamics controller
-        controller_account_name: "customer1" # Please add this to your Vault
+        # Your controller details
+        # controller_account_access_key: "b0248ceb-c954-4a37-97b5-207e90418cb4" # Please add this to your Vault
+        # controller_global_analytics_account_name: "customer1_e2f90621-ab21-4bf4-908c-872d213c7f64" # Please add this to your Vault
+        # controller_host_name: "ansible-20100nosshcont-bum4wzwa.appd-cx.com" # Your AppDynamics controller
+        # controller_account_name: "customer1" # Please add this to your Vault
         sim_enabled: "true"
-        enable_ssl: "false"
-        controller_port: "8090"
-        analytics_event_endpoint: "http://ansible-20100nosshcont-bum4wzwa.appd-cx.com:7001"
-        enable_analytics_agent: "true"
+        # enable_ssl: "false"
+        # controller_port: "8090"
+        # analytics_event_endpoint: "http://ansible-20100nosshcont-bum4wzwa.appd-cx.com:7001"
+        # enable_analytics_agent: "true"
         machine_hierarchy: "AppName|Owners|Environment|" # Make sure it ends with a |

--- a/playbooks/machine.yaml
+++ b/playbooks/machine.yaml
@@ -1,20 +1,21 @@
 ---
 - hosts: linux
   tasks:
+    - include_vars: vars/controller.yaml
     - include_role:
         name: appdynamics.agents.machine
       vars:
         # Define Agent Type and Version
         agent_version: 20.9.0
-        agent_type: machine 
-        # Your controller details 
-        controller_account_access_key: "b0248ceb-c954-4a37-97b5-207e90418cb4" # Please add this to your Vault
-        controller_global_analytics_account_name: 'customer1_e2f90621-ab21-4bf4-908c-872d213c7f64' # Please add this to your Vault
-        controller_host_name: "ansible-20100nosshcont-bum4wzwa.appd-cx.com" # Your AppDynamics controller
-        controller_account_name: "customer1" # Please add this to your Vault
+        agent_type: machine
+        # Your controller details
+        # controller_account_access_key: "b0248ceb-c954-4a37-97b5-207e90418cb4" # Please add this to your Vault
+        # controller_global_analytics_account_name: 'customer1_e2f90621-ab21-4bf4-908c-872d213c7f64' # Please add this to your Vault
+        # controller_host_name: "ansible-20100nosshcont-bum4wzwa.appd-cx.com" # Your AppDynamics controller
+        # controller_account_name: "customer1" # Please add this to your Vault
         sim_enabled: "true"
-        enable_ssl: "false"
-        controller_port: "8090"
-        analytics_event_endpoint: "http://ansible-20100nosshcont-bum4wzwa.appd-cx.com:7001"
-        enable_analytics_agent: "true"
+        # enable_ssl: "false"
+        # controller_port: "8090"
+        # analytics_event_endpoint: "http://ansible-20100nosshcont-bum4wzwa.appd-cx.com:7001"
+        # ßenable_analytics_agent: "true"
         machine_hierarchy: "AppName|Owners|Environment|" # Make sure it ends with a |

--- a/playbooks/vars/controller.yaml
+++ b/playbooks/vars/controller.yaml
@@ -1,0 +1,8 @@
+controller_host_name: "lncontroller20103-2010-o8evv8rp.appd-cx.com" # Your AppDynamics controller
+controller_account_name: "customer1" # Please add this to your Vault
+controller_account_access_key: "2498dd59-d059-48c1-8ec2-8dc2f3efa112" # Please add this to your Vault
+enable_ssl: "FALSE"
+controller_port: "8090"
+analytics_event_endpoint: "https://fra-ana-api.saas.appdynamics.com:443"
+enable_analytics_agent: "true"
+controller_global_analytics_account_name: 'customer1_e52eb4e7-25d2-41c4-a5bc-9685502317f2' # Please add this to your Vault

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+# Reference the Java role from ansible galaxy
+roles:
+  # Install a role from Ansible Galaxy.
+  - name: lean_delivery.java

--- a/roles/common/defaults/main.yaml
+++ b/roles/common/defaults/main.yaml
@@ -18,7 +18,7 @@ db_agent_dest_folder_linux: /opt/appdynamics/db-agent
 db_agent_dest_file: db-agent.zip
 db_agent_name: "AppDynamics"
 
-# DB Agent Linux
+# DB Agent Windows
 db_agent_dest_folder_windows: C:/appdynamics/db-agent
 
 # Machine Agent Win

--- a/roles/common/defaults/main.yaml
+++ b/roles/common/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-#wheel user for Machine agent 
+#wheel user for Machine agent
 appdynamics_user: appdynamics
 
 
@@ -11,12 +11,15 @@ win_db_finder_string: db-agent-winx64
 linux_ma_finder_string: machineagent-bundle-64bit-linux
 linux_db_finder_string: db-agent
 
-host_name: '{{ ansible_hostname }}' # computername/hostname of the target machine 
+host_name: '{{ ansible_hostname }}' # computername/hostname of the target machine
 
 # DB Agent Linux
 db_agent_dest_folder_linux: /opt/appdynamics/db-agent
 db_agent_dest_file: db-agent.zip
 db_agent_name: "AppDynamics"
+
+# DB Agent Linux
+db_agent_dest_folder_windows: C:/appdynamics/db-agent
 
 # Machine Agent Win
 machine_agent_dest_folder_win: C:/appdynamics/machine-agent
@@ -27,23 +30,23 @@ temp_dir: /tmp
 machine_agent_dest_folder_linux: /opt/appdynamics/machine-agent
 machine_agent_monitor_folder_linux: "{{ machine_agent_dest_folder_linux }}/monitor/"
 
-# Machine Common 
+# Machine Common
 ma_agent_dest_file: machine-agent.zip
-machine_hierarchy: "" 
+machine_hierarchy: ""
 
 # DotNet Agent Win
-dotnet_agent_dest_folder_win: C:\\appdynamics\\dotnet-agent # '/' does not work with win_package due to msiexec. 
+dotnet_agent_dest_folder_win: C:\\appdynamics\\dotnet-agent # '/' does not work with win_package due to msiexec.
 dotnet_agent_dest_file: dotNetAgentSetup64.msi
 
-# Java Agent Linux 
+# Java Agent Linux
 java_agent_dest_folder_linux: /opt/appdynamics/java-agent
 java_agent_dest_file: java-agent.zip
 
-# Java Agent Windows 
+# Java Agent Windows
 java_agent_dest_folder_win: C:/appdynamics/java-agent
 
-# DotNet agent defaults 
-monitor_all_IIS_apps: false 
+# DotNet agent defaults
+monitor_all_IIS_apps: false
 runtime_reinstrumentation: false
 
 #controller defaults

--- a/roles/common/files/get-agent.sh
+++ b/roles/common/files/get-agent.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# This script is not officially supported by AppDynamics 
-# Author: Israel Ogbole 
+# This script is not officially supported by AppDynamics
+# Author: Israel Ogbole
 
 set -o nounset
 
@@ -24,7 +24,8 @@ readonly ERR_MISSING_LIB_DEPS=8
 readonly ERR_UNSUPPORTED_PLATFORM=9
 readonly ERR_GENERIC=10
 
-DOWNLOAD_PAGE_OUTPUT="tmp.json"
+# DOWNLOAD_PAGE_OUTPUT=$(mktemp ./tmp.XXXXXX) # "tmp.json"
+# ßecho $DOWNLOAD_PAGE_OUTPUT
 
 #download page search params
 _app_agent=""
@@ -35,6 +36,8 @@ _version=""
 
 # Switch to the script's directory.
 cd "${HERE}" || exit
+
+DOWNLOAD_PAGE_OUTPUT=$(mktemp tmp.XXXXXX) # "tmp.json" - using a static mane here seems to cause clashes
 
 ###################################################################################################################
 #                                   USAGE AND ERROR HANDLING FUNCTIONS                                            #
@@ -103,7 +106,6 @@ exit_bad_args() {
 cleanup() {
   rm -f "${HTTP_STATUS_FILE}"
   rm -f ${DOWNLOAD_PAGE_OUTPUT}
-
 }
 trap cleanup EXIT TERM INT
 
@@ -158,7 +160,7 @@ download_options() {
     _app_agent="dotnet"
     _finder="dotNetAgentSetup64"
     _os_platform="windows"
-    
+
   elif [ "$1" = "dotnet-core" ]; then
     _app_agent="dotnet,dotnet-core"
     _finder="AppDynamics-DotNetCore-linux-x64"
@@ -182,7 +184,7 @@ download_options() {
 # argument results in exit with `ERR_BAD_ARGS`.
 #
 # Args:
-#   $1 - agent type 
+#   $1 - agent type
 #   $3 - agent version
 # Returns:
 #   the downlod URL for the specified agent and version.
@@ -193,6 +195,12 @@ get_download_url() {
   portal_page="https://download.appdynamics.com/download/downloadfile/?version=${_version}&apm=${_app_agent}&os=${_os_platform}&platform_admin_os=${_os_platform}&events=${_events}&eum=${_eum}&apm_os=${_os_platform}"
 
   http_response=$(curl -s -o ${DOWNLOAD_PAGE_OUTPUT} -w "%{http_code}" -X GET "$portal_page")
+  # echo "http_response=\$(curl -s -o ${DOWNLOAD_PAGE_OUTPUT} -w \"%{http_code}\" -X GET \"$portal_page\")"
+  # echo $http_response
+  # cat ${DOWNLOAD_PAGE_OUTPUT}
+  # echo " ------ "
+  # pwd
+
 
   if [ "${http_response}" -ge 400 ] && [ "${http_code}" -lt 600 ]; then
     exit_with_error "bad HTTP response code: ${http_response}" "${ERR_BAD_RESPONSE}"
@@ -270,7 +278,7 @@ do_unzip() {
 #                                            DOWLOAD COMMAND FUNCTION                                                   #
 ###################################################################################################################
 
-# Implements the `download` sub-command. 
+# Implements the `download` sub-command.
 #
 # Args: [agent-type] --version VERSION --dryrun
 download() {

--- a/roles/common/tasks/get_agent.yml
+++ b/roles/common/tasks/get_agent.yml
@@ -1,12 +1,25 @@
 ---
+# LN - Initialize the qualified_agent_type
+# This allows a generic agent type to be used, rather than an OS specific one
+# We set the OS specific agent type based on the base type and os family
+- set_fact:
+    qualified_agent_type: "{{ agent_type }}"
+
+# Override the agent type for the DB agent on Window. The windows package
+# includes scripts to install the agent as a service.
+- name: Adjust the agent type to match the target OS
+  set_fact:
+    qualified_agent_type: "db-win"
+  when: ansible_os_family == 'Windows' and agent_type == 'db'
+
 - name: "Get AppDynamics Agent Download URL type"
-  command: "{{ role_path }}/files/get-agent.sh download {{ agent_type }} -v {{ agent_version }} --dryrun"
+  command: "{{ role_path }}/files/get-agent.sh download {{ qualified_agent_type }} -v {{ agent_version }} --dryrun"
   register: agent_download_url
   delegate_to: localhost
   failed_when:
-   (agent_download_url.rc != 0) or 
+   (agent_download_url.rc != 0) or
    (agent_download_url.stdout is not match("https://download-files.appdynamics.com/download-file/"))
   changed_when: False
 
-- debug: 
-   msg: "{{ agent_download_url.stdout }}"
+- debug:
+   msg: "Agent Download URL = {{ agent_download_url.stdout }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,7 +1,6 @@
 - include_tasks: validate_parameters.yml
 
 #- include_tasks: install_jq.yml
-
 - debug:
      msg:  "Agent variables: type=> {{ agent_type }} version=> {{ agent_version }}"
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 
 #- include_tasks: install_jq.yml
 
-- debug: 
+- debug:
      msg:  "Agent variables: type=> {{ agent_type }} version=> {{ agent_version }}"
 
 - include_tasks: get_agent.yml
@@ -14,30 +14,30 @@
 
 - name: Set Controller Proxy configuration
   set_fact:
-    enable_proxy: "{{ enable_proxy }} | bool | lower"
-  
+    enable_proxy: "{{ enable_proxy | bool | lower }}"
+
 - name: Set AppDynamics controller facts
   set_fact:
     account_name: "{{ controller_account_name }}"
     global_analytics_account_name: "{{ controller_global_analytics_account_name }}"
     controller_host_name: "{{ controller_host_name }}"
     analytics_event_endpoint: "{{ analytics_event_endpoint }}"
-    sim_enabled: "{{ sim_enabled }} | bool | lower"
-    enable_ssl: "{{ enable_ssl }} | bool | lower "
+    sim_enabled: "{{ sim_enabled  | bool | lower }}"
+    enable_ssl: "{{ enable_ssl | bool | lower }}"
     controller_port: "{{ controller_port }}"
-    enable_analytics_agent: "{{ enable_analytics_agent }} | bool | lower"
+    enable_analytics_agent: "{{ enable_analytics_agent  | bool | lower }}"
     machine_hierarchy: "{{ machine_hierarchy }}"
 
 - name: Set HTTPS Protocol facts
   set_fact:
     controller_protocol: "{% if enable_ssl|bool %}https{% else %}http{% endif %}"
 
-- name: Print params 
+- name: Print params
   vars:
      params: "
       SSL enabled = {{ enable_ssl }} |
       Controller={{ controller_protocol }}://{{ controller_host_name }}:{{ controller_port }} |
       controller_account_name={{ controller_account_name }} |
       analytics_event_endpoint={{ analytics_event_endpoint }} "
-  debug: 
+  debug:
     msg: "{{ params.split('|') }}"

--- a/roles/common/vars/main/controller_vars.yml
+++ b/roles/common/vars/main/controller_vars.yml
@@ -1,7 +1,7 @@
 ---
 analytics_event_endpoint: "https://fra-ana-api.saas.appdynamics.com:443"
-sim_enabled: false
-enable_ssl: false
+sim_enabled: "false"
+enable_ssl: "false"
 controller_port: "443"
 controller_account_name: "customer1"
 controller_global_analytics_account_name: "customer1-guid"

--- a/roles/db/meta/main.yml
+++ b/roles/db/meta/main.yml
@@ -29,12 +29,12 @@ galaxy_info:
         - 7
         - 6
   galaxy_tags:
-    - apm 
+    - apm
     - monitoring
     - appdynamics
 
 dependencies:
  - { role: common }
- - { role: linux_pkg, when: ansible_os_family == 'RedHat' or  ansible_os_family == 'Debian'}
- #- { role: win_pkg, when: ansible_os_family == 'Windows' }
+ - { role: linux_pkg, when: ansible_os_family == 'RedHat' or ansible_os_family == 'Debian'}
+ - { role: win_pkg, when: ansible_os_family == 'Windows' }
  #when: lookup('env', 'MOLECULE_FILE')

--- a/roles/db/tasks/install_db_agent_linux.yml
+++ b/roles/db/tasks/install_db_agent_linux.yml
@@ -74,12 +74,27 @@
       when: previous_db_agent.stat.exists
       changed_when: false
 
-    - name: Clean up old agent after backup
-      command: "rm -rf {{ db_agent_dest_folder_linux }}/*"
-      args:
-         warn: false
-      when: previous_db_agent.stat.exists
+    # - name: Clean up old agent after backup
+    #   command: "rm -rf {{ db_agent_dest_folder_linux }}/*"
+    #   args:
+    #      warn: false
+    #   when: previous_db_agent.stat.exists
+    #   changed_when: false
+    - name: Clean up old DB Agent binaries after backup
+      file:
+        path: "{{ db_agent_dest_folder_linux }}"
+        state: absent
       changed_when: false
+
+    - name: Ensures DB agent dir exists
+      file:
+        path: "{{ db_agent_dest_folder_linux }}/"
+        state: directory
+        mode: 0755
+        owner: "{{ appdynamics_user }}"
+        group: "{{ appdynamics_user }}"
+        recurse: yes
+      changed_when: false # this ensures this task is idempotent
 
     - name: Download DB Agent
       get_url:

--- a/roles/db/tasks/install_db_agent_linux.yml
+++ b/roles/db/tasks/install_db_agent_linux.yml
@@ -1,46 +1,47 @@
 ---
 - name: DB Agent Linux Block
   become: true
-  block: 
+  block:
     - include_tasks: appd_sudoer.yml
 
     - include_tasks: install_java_linux.yml
+      when: install_jre == true or install_jre is undefined
 
     - name: Ensures DB agent dir exists
-      file: 
+      file:
         path: "{{ db_agent_dest_folder_linux }}/"
-        state: directory     
+        state: directory
         mode: 0755
         owner: "{{ appdynamics_user }}"
         group: "{{ appdynamics_user }}"
         recurse: yes
-      changed_when: false # this ensures this task is idempotent 
+      changed_when: false # this ensures this task is idempotent
 
-    - name: Clean out orphanned {{ db_agent_dest_file }} 
+    - name: Clean out orphanned {{ db_agent_dest_file }}
       file:
         path: "{{ db_agent_dest_folder_linux }}/{{ db_agent_dest_file }}"
-        state: absent  
-      changed_when: false # this ensures this task is idempotent 
-      
+        state: absent
+      changed_when: false # this ensures this task is idempotent
+
     - name: Check if DB agent exists
       stat: path="{{ db_agent_dest_folder_linux }}/db-agent.jar"
       register: previous_db_agent
-      
+
     - name: Backup old DB agent to /tmp folder
-      archive: 
+      archive:
         path: "{{ db_agent_dest_folder_linux }}"
         dest: "/tmp/db_agent.{{ ansible_date_time.iso8601 }}.zip"
         mode: 0755
       when: previous_db_agent.stat.exists
       changed_when: false
-    
+
     - name: Get running DB processes
       shell: "ps -ef | grep -v grep | grep -w 'db-agent' | awk '{print $2}'"
       register: running_processes
       when: previous_db_agent.stat.exists
       changed_when: false
-    
-    - debug: 
+
+    - debug:
        msg: "{{ running_processes.stdout_lines  }}"
       when: previous_db_agent.stat.exists
       changed_when: false
@@ -48,10 +49,10 @@
     - name: Kill running DB processes
       command: "kill {{ item }}"
       with_items: "{{ running_processes.stdout_lines }}"
-      ignore_errors: yes  # Skip 'kill: No such process' errors 
+      ignore_errors: yes  # Skip 'kill: No such process' errors
       when: previous_db_agent.stat.exists
       changed_when: false
-    
+
     - name: Force Kill DB process
       wait_for:
         path: "/proc/{{ item }}/status"
@@ -62,7 +63,7 @@
       when: previous_db_agent.stat.exists
       changed_when: false
 
-    - debug: 
+    - debug:
        msg: "{{ running_processes.stdout_lines }}"
       when: previous_db_agent.stat.exists
       changed_when: false
@@ -73,32 +74,34 @@
       when: previous_db_agent.stat.exists
       changed_when: false
 
-    - name: Clean up old agent after backup  
+    - name: Clean up old agent after backup
       command: "rm -rf {{ db_agent_dest_folder_linux }}/*"
       args:
          warn: false
       when: previous_db_agent.stat.exists
       changed_when: false
 
-    - name: Download DB Agent 
+    - name: Download DB Agent
       get_url:
         url: '{{ agent_download_url.stdout }}'
         dest: "{{ db_agent_dest_folder_linux }}/{{ db_agent_dest_file }}"
-        force: true # download a new file even if dbagent.zip exists. 
+        force: true # download a new file even if dbagent.zip exists.
       changed_when: false
       register: result
       failed_when: result.status_code != 200
 
-    - debug: 
-        msg: "{{ result }}" 
+    - debug:
+        msg: "{{ result }}"
 
-    - name: Unzip DB agent file 
-      unarchive: 
-        #src: "{{ agent_download_url.stdout }}" 
+    - name: Unzip DB agent file
+      unarchive:
+        #src: "{{ agent_download_url.stdout }}"
         src: "{{ db_agent_dest_folder_linux }}/{{ db_agent_dest_file }}"
-        dest: "{{ db_agent_dest_folder_linux }}" 
+        dest: "{{ db_agent_dest_folder_linux }}"
         mode: 0755
-        remote_src: yes 
+        remote_src: yes
+        owner: "{{ appdynamics_user }}"
+        group: "{{ appdynamics_user }}"
       changed_when: false
 
     - name: Configure db-agent controller-info.xml file
@@ -107,7 +110,7 @@
         dest: '{{ db_agent_dest_folder_linux }}/conf/controller-info.xml'
         owner: "{{ appdynamics_user }}"
         group: "{{ appdynamics_user }}"
-        mode: 0755  
+        mode: 0755
       changed_when: false
 
     - name: Add the DB Agent as a Service using Systemd
@@ -115,9 +118,9 @@
         src: templates/appdynamics-db-agent.service.j2
         dest: /etc/systemd/system/appdynamics-db-agent.service
         force: true
-        owner: root # The Machine Agent must not run as root, you may change it. 
+        owner: root # The Machine Agent must not run as root, you may change it.
         group: root
-        mode: 0644  
+        mode: 0644
       register: db_agent_systemd_result
 
     - name: Enable the DB Agent to start at system startup
@@ -126,7 +129,7 @@
         enabled: yes
         force: true # Force it to override existing symlink incase of an upgrade
         masked: no
-    
+
     - name: Start the agent service
       systemd:
         name: appdynamics-db-agent
@@ -140,24 +143,24 @@
       ignore_errors: yes
       changed_when: false
 
-    - name: Show DB Agent status 
+    - name: Show DB Agent status
       debug:
         var: result
-  
+
     #- name: Start DB Agent service
     #  shell: "nohup java -Dappdynamics.agent.uniqueHostId={{ host_name }} -Ddbagent.name={{ db_agent_name }} -Xms1536m -jar {{ db_agent_dest_folder_linux }}/db-agent.jar </dev/null >/dev/null 2>&1 &"
       #shell: "{{ db_agent_dest_folder_linux }}/start-dbagent  -Dappdynamics.agent.uniqueHostId={{ host_name }} -Ddbagent.name={{ db_agent_name }} -Xms1536m  </dev/null >/dev/null 2>&1 &"
-   
+
     - name: Get new running DB processes
       shell: "ps -ef | grep -v grep | grep -w 'db-agent' | awk '{print $2}'"
       register: db_proc
       changed_when: false
 
-    - debug: 
+    - debug:
        msg: "{{ db_proc.stdout_lines }}"
 
-    - name: Clean up - remove {{ db_agent_dest_file }} 
+    - name: Clean up - remove {{ db_agent_dest_file }}
       file:
         path: "{{ db_agent_dest_folder_linux }}/{{ db_agent_dest_file }}"
         state: absent
-      changed_when: false 
+      changed_when: false

--- a/roles/db/tasks/install_db_agent_windows.yml
+++ b/roles/db/tasks/install_db_agent_windows.yml
@@ -1,0 +1,65 @@
+---
+# - include_tasks: install_java_windows.yml
+#  when: install_jre == true or install_jre is undefined
+
+- include_tasks: install_java_windows.yml
+  when: install_jre == true or install_jre is undefined
+
+# App owners would either need to chown the entire agent folder to their app's user  OR grant their app's user read/write access to the agent folder
+- name: Ensures application agent {{ db_agent_dest_folder_windows }} dir exists
+  win_file:
+    path: "{{ db_agent_dest_folder_windows }}/"
+    state: directory
+
+- name: Remove previous {{ db_agent_dest_file }}
+  win_file:
+    path: "{{ db_agent_dest_folder_windows }}/{{ db_agent_dest_file }}"
+    state: absent
+  changed_when: false # this ensures this task is idempotent
+
+- name: Check if DB agent exists
+  win_stat: path="{{ db_agent_dest_folder_windows }}/db-agent.jar"
+  register: previous_agent
+
+#using Powershell as win_zip module doesn't exist in Ansible - 10/2020
+- name: Backup old DB agent to  C:\Windows\Temp folder
+  win_shell: "Compress-Archive -Path {{ db_agent_dest_folder_windows }} -DestinationPath  C:/Windows/Temp/db-agent.{{ ansible_date_time.iso8601 }}.zip -Force"
+  when: previous_agent.stat.exists
+  changed_when: false
+
+- name: Clean up old agent after backup
+  win_shell: "Remove-Item {{ db_agent_dest_folder_windows }}/* -Recurse"
+  args:
+      warn: false
+  when: previous_agent.stat.exists
+  changed_when: false
+
+- name: Downloading DB Agent
+  win_get_url:
+    url: '{{ agent_download_url.stdout }}'
+    dest: '{{ db_agent_dest_folder_windows }}/{{ db_agent_dest_file }}'
+    force: 'true'
+  changed_when: false
+  register: result
+  failed_when: result.status_code != 200
+
+- debug:
+    msg: "{{ result }}"
+
+- name: Unzip the DB agent
+  win_unzip:
+    src: "{{ db_agent_dest_folder_windows }}/{{ db_agent_dest_file }}"
+    dest: "{{ db_agent_dest_folder_windows }}"
+    remote_src: yes
+  changed_when: false
+
+- name: Configure DB agent's controller-info.xml
+  template:
+    src: templates/db-agent-controller-info.xml.j2
+    dest: "{{ db_agent_dest_folder_windows }}/conf/controller-info.xml"
+  changed_when: false
+
+- name: Clean up - remove {{ db_agent_dest_file }}
+  win_file:
+    path: "{{ db_agent_dest_folder_windows }}/{{ db_agent_dest_file }}"
+    state: absent

--- a/roles/db/tasks/install_db_agent_windows.yml
+++ b/roles/db/tasks/install_db_agent_windows.yml
@@ -27,6 +27,14 @@
   when: previous_agent.stat.exists
   changed_when: false
 
+- name: Remove the DB agent service
+  win_command: cscript.exe "{{ db_agent_dest_folder_windows }}/UninstallService.vbs"
+  register: uninstall_win_service_result
+  when: previous_agent.stat.exists
+
+- debug:
+    msg: "{{ uninstall_win_service_result }}"
+
 - name: Clean up old agent after backup
   win_shell: "Remove-Item {{ db_agent_dest_folder_windows }}/* -Recurse"
   args:
@@ -63,3 +71,10 @@
   win_file:
     path: "{{ db_agent_dest_folder_windows }}/{{ db_agent_dest_file }}"
     state: absent
+
+- name: 'Install DB agent service'
+  win_command: cscript.exe "{{ db_agent_dest_folder_windows }}/InstallService.vbs" -Ddbagent.name="{{db_agent_name}}"
+  register: install_win_service_result
+
+- debug:
+    msg: "{{ install_win_service_result }}"

--- a/roles/db/tasks/install_java_windows.yml
+++ b/roles/db/tasks/install_java_windows.yml
@@ -1,0 +1,3 @@
+---
+- include_role:
+    name: lean_delivery.java

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -1,6 +1,5 @@
 - include_tasks: install_db_agent_linux.yml
   when: ansible_os_family == 'RedHat' or  ansible_os_family == 'Debian'
 
-#todo
-#- include_tasks: install_db_agent_windows.yml 
-#  when: ansible_os_family == 'Windows'
+- include_tasks: install_db_agent_windows.yml
+  when: ansible_os_family == 'Windows'

--- a/roles/db/templates/appdynamics-db-agent.service.j2
+++ b/roles/db/templates/appdynamics-db-agent.service.j2
@@ -3,7 +3,7 @@
 Description=AppDynamics Database Agent
 
 [Service]
-# You may change the user running the process if you so wish, but ensure the user can read and write to the {{ db_agent_dest_folder_linux }} path. 
+# You may change the user running the process if you so wish, but ensure the user can read and write to the {{ db_agent_dest_folder_linux }} path.
 User={{ appdynamics_user }}
 
 # Killing the service using systemd causes Java to exit with status 143. This is OK.
@@ -12,8 +12,8 @@ SuccessExitStatus=143
 Type=simple
 
 # ExecStart=/user/bin/java -Dappdynamics.agent.uniqueHostId={{ host_name }} -Ddbagent.name={{ db_agent_name }} -Xms1536m -jar {{ db_agent_dest_folder_linux }}/db-agent.jar >/dev/null 2>&1 &
-ExecStart=/bin/sh -c {{ db_agent_dest_folder_linux }}/start-dbagent -Dappdynamics.agent.uniqueHostId={{ host_name }} -Ddbagent.name={{ db_agent_name }} -Xms1536m >/dev/null 2>&1 &
-ExecStop=/bin/kill -2 $MAINPID 
+ExecStart=/bin/sh -c "{{ db_agent_dest_folder_linux }}/start-dbagent -Dappdynamics.agent.uniqueHostId={{ host_name }} -Ddbagent.name={{ db_agent_name }} -Xms1536m"
+ExecStop=/bin/kill -2 $MAINPID
 
 [Install]
 # Start the AppDynamics DB agent service during the setup for a

--- a/roles/java/tasks/java-agent-linux.yml
+++ b/roles/java/tasks/java-agent-linux.yml
@@ -1,43 +1,44 @@
 ---
-# App owners would either need to chown the entire agent folder to their app's user  OR grant their app's user read/write access to the agent folder 
+# App owners would either need to chown the entire agent folder to their app's user  OR grant their app's user read/write access to the agent folder
 - name: Java Linux Block
   become: true
-  block: 
-    - name: Clean out orphanned {{ java_agent_dest_file }} 
+  block:
+    - name: Clean out orphanned {{ java_agent_dest_file }}
       file:
         path: "{{ java_agent_dest_folder_linux }}/{{ java_agent_dest_file }}"
-        state: absent  
-      changed_when: false # this ensures this task is idempotent 
-      
+        state: absent
+      changed_when: false # this ensures this task is idempotent
+
     - name: Check if java agent exists
       stat: path="{{ java_agent_dest_folder_linux }}/javaagent.jar"
       register: previous_agent
-      
+
     - name: Backup old java agent to /tmp folder
-      archive: 
+      archive:
         path: "{{ java_agent_dest_folder_linux }}"
         dest: "/tmp/java_agent.{{ ansible_date_time.iso8601 }}.zip"
         mode: 0755
       when: previous_agent.stat.exists
       changed_when: false
-             
-    - name: Clean up old agent after backup  
+
+# Todo : Make sure the directory is properly cleared out
+    - name: Clean up old agent after backup
       shell: "rm -rf {{ java_agent_dest_folder_linux }}/*"
       args:
          warn: false
       when: previous_agent.stat.exists
       changed_when: false
-  
+
     - name: Ensures application agent dir exists
-      file: 
+      file:
         path: "{{ java_agent_dest_folder_linux }}/"
-        state: directory     
+        state: directory
         mode: 0755
         recurse: yes
-      changed_when: false # this ensures this task is idempotent 
+      changed_when: false # this ensures this task is idempotent
 
      # add delegate_to: localhost for customers who are unable to download on the remote server
-    - name: Download Java Agent 
+    - name: Download Java Agent
       get_url:
         url: "{{ agent_download_url.stdout }}"
         dest: "{{ java_agent_dest_folder_linux }}/{{ java_agent_dest_file }}"
@@ -46,33 +47,59 @@
       register: result
       failed_when: result.status_code != 200
 
-    - debug: 
-         msg: "{{ result }}" 
-     
+    - debug:
+         msg: "{{ result }}"
+
     # Keeping downloading and unziping seperate tasks
-    # as not all customers are allowd to download on the remote servers. 
-    - name: Unzip the Java agent file 
-      unarchive: 
-        #src: "{{ agent_download_url.stdout }}" 
+    # as not all customers are allowd to download on the remote servers.
+    - name: Unzip the Java agent file
+      unarchive:
+        #src: "{{ agent_download_url.stdout }}"
         src: "{{ java_agent_dest_folder_linux }}/{{ java_agent_dest_file }}"
         dest: "{{ java_agent_dest_folder_linux }}"
         mode: 0755
-        remote_src: yes 
+        remote_src: yes
       changed_when: false
 
     - name: Configure Java agent's controller-info.xml
       template:
         src: templates/application-agent-controller-info.xml.j2
         dest: '{{ java_agent_dest_folder_linux }}/conf/controller-info.xml'
-        mode: 0755  
+        mode: 0755
       changed_when: false
 
-    - name: Copy controller-info.xml to the versioned agent folder 
+    - name: Copy controller-info.xml to the versioned agent folder
       shell: cp  {{ java_agent_dest_folder_linux }}/conf/controller-info.xml  {{ java_agent_dest_folder_linux }}/ver{{ agent_version }}*/conf/
       changed_when: false
 
-    - name: Clean up - remove {{ java_agent_dest_file }} 
+    - name: Change the ownership if the java agent directories and files if the apm_user is set
+      file:
+        dest: '{{ java_agent_dest_folder_linux }}'
+        owner: '{{apm_user}}'
+        group: '{{apm_user}}'
+        mode: u=rwX,g=rX,o=rX
+        recurse: false
+      register: result
+      when: (apm_user is defined) and (apm_user|length > 0)
+
+
+    - name: Change the ownership of content
+      file:
+        dest: '{{ java_agent_dest_folder_linux }}/'
+        owner: '{{apm_user}}'
+        group: '{{apm_user}}'
+        mode: u=rwX,g=rX,o=rX
+        recurse: true
+      register: result
+      when: (apm_user is defined) and (apm_user|length > 0)
+      changed_when: false
+
+
+    - debug:
+        msg: '{{result}}'
+
+    - name: Clean up - remove {{ java_agent_dest_file }}
       file:
         path: "{{ java_agent_dest_folder_linux }}/{{ java_agent_dest_file }}"
-        state: absent  
+        state: absent
       changed_when: false # this ensures this task is idempotent

--- a/roles/java/tasks/java-agent-windows.yml
+++ b/roles/java/tasks/java-agent-windows.yml
@@ -1,15 +1,15 @@
 ---
-# App owners would either need to chown the entire agent folder to their app's user  OR grant their app's user read/write access to the agent folder 
+# App owners would either need to chown the entire agent folder to their app's user  OR grant their app's user read/write access to the agent folder
 - name: Ensures application agent {{ java_agent_dest_folder_win }} dir exists
-  win_file: 
+  win_file:
     path: "{{ java_agent_dest_folder_win }}/"
-    state: directory     
+    state: directory
 
-- name: Remove previous {{ java_agent_dest_file }} 
+- name: Remove previous {{ java_agent_dest_file }}
   win_file:
     path: "{{ java_agent_dest_folder_win }}/{{ java_agent_dest_file }}"
-    state: absent  
-  changed_when: false # this ensures this task is idempotent 
+    state: absent
+  changed_when: false # this ensures this task is idempotent
 
 - name: Check if java agent exists
   win_stat: path="{{ java_agent_dest_folder_win }}/javaagent.jar"
@@ -21,7 +21,7 @@
   when: previous_agent.stat.exists
   changed_when: false
 
-- name: Clean up old agent after backup  
+- name: Clean up old agent after backup
   win_shell: "Remove-Item {{ java_agent_dest_folder_win }}/* -Recurse"
   args:
       warn: false
@@ -37,14 +37,14 @@
   register: result
   failed_when: result.status_code != 200
 
-- debug: 
-         msg: "{{ result }}" 
+- debug:
+         msg: "{{ result }}"
 
-- name: Unzip the Java agent 
-  win_unzip: 
+- name: Unzip the Java agent
+  win_unzip:
     src: "{{ java_agent_dest_folder_win }}/{{ java_agent_dest_file }}"
-    dest: "{{ java_agent_dest_folder_win }}"  
-    remote_src: yes 
+    dest: "{{ java_agent_dest_folder_win }}"
+    remote_src: yes
   changed_when: false
 
 - name: Configure Java agent's controller-info.xml
@@ -57,15 +57,17 @@
 - name: "Get version folder name"
   win_shell: "(Get-ChildItem {{ java_agent_dest_folder_win }} -Recurse -Depth 1 | Where{$_.Name -Match 'ver*'}  | Select-Object -ExpandProperty Name).Trim()"
   register: ver
+  changed_when: false
 
 - debug:
     msg: "{{ ver.stdout | regex_replace ('\\r\\n', '') }}"
-  
-- name: Copy controller-info.xml to the versioned agent folder 
+
+- name: Copy controller-info.xml to the versioned agent folder
   win_shell: "Copy-Item  {{ java_agent_dest_folder_win }}/conf/controller-info.xml  {{ java_agent_dest_folder_win }}/{{ ver.stdout | regex_replace ('\\r\\n', '') }}/conf/ -Force"
   changed_when: false
 
-- name: Clean up - remove {{ java_agent_dest_file }} 
+- name: Clean up - remove {{ java_agent_dest_file }}
   win_file:
     path: "{{ java_agent_dest_folder_win }}/{{ java_agent_dest_file }}"
     state: absent
+  changed_when: false

--- a/roles/machine/tasks/install_machine_agent_linux.yml
+++ b/roles/machine/tasks/install_machine_agent_linux.yml
@@ -1,47 +1,72 @@
 ---
-- name: Validate that the agent download URL is fit for Linux 
+- name: Validate that the agent download URL is fit for Linux
   assert:
     that: "linux_ma_finder_string in agent_download_url.stdout"
     fail_msg: "It looks like you have downloaded the Windows machine agent instead of the Linux machine agent. You entered '{{ agent_type }}' in the playbook. The URL: {{ agent_download_url.stdout }} is expected to contain {{ linux_ma_finder_string }}"
     success_msg: "Successfully validated {{ agent_type }} for Linux"
-    
+
 - name: Machine Agent linux Block
   become: true
-  block: 
+  block:
   - include_tasks: appd_sudoer.yml
   - name: Ensures machine agent {{ machine_agent_dest_folder_linux }} dir exists
-    file: 
+    file:
       path: "{{ machine_agent_dest_folder_linux }}/"
-      state: directory     
+      state: directory
       mode: 0755
       owner: "{{ appdynamics_user }}"
       group: "{{ appdynamics_user }}"
-   
+
   - name: Check if Machine Agent is already installed
     stat: path="{{ machine_agent_dest_folder_linux }}/machineagent.jar"
     register: previous_agent
-    
+
   - name: Backup existing Machine Agent
-    archive: 
+    archive:
       path: "{{ machine_agent_dest_folder_linux }}"
       dest: "/tmp/machine_agent.{{ ansible_date_time.iso8601 }}.zip"
       mode: 0755
     when: previous_agent.stat.exists
     changed_when: false
-  
+
   - name: Stop Machine Agent service
     systemd:
       name: appdynamics-machine-agent
       state: stopped
       daemon_reload: yes
     changed_when: false
+    register: result
     when: previous_agent.stat.exists
-    
-  - name: Clean up old Machine Agent binaries after backup  
-    command: "rm -rf {{ machine_agent_dest_folder_linux }}/*"
-    args:
-        warn: false
-    when: previous_agent.stat.exists
+
+
+# -[ LN ]----------------------------------------------------------
+# the rm -rf /dir/* does not appear to work relibly. The directory
+# content appears not to get delete. When installing a new agent
+# over the existing one, old file remain which can cause the agent
+# not to work (it runs but does not collect any metrics )
+# The workaround is to delete the directory and re-create it
+
+#  - name: Clean up old Machine Agent binaries after backup
+#    command: "rm -rf {{ machine_agent_dest_folder_linux }}/*"
+#    register: result
+#    args:
+#        warn: false
+#    when: previous_agent.stat.exists
+#    changed_when: false
+# -----------------------------------------------------------------
+  - name: Clean up old Machine Agent binaries after backup
+    file:
+      path: "{{ machine_agent_dest_folder_linux }}"
+      state: absent
+    changed_when: false
+
+  - name: Re-create the machine agent {{ machine_agent_dest_folder_linux }} dir
+    file:
+      path: "{{ machine_agent_dest_folder_linux }}/"
+      state: directory
+      mode: 0755
+      owner: "{{ appdynamics_user }}"
+      group: "{{ appdynamics_user }}"
     changed_when: false
 
   - name: Downloading Machine Agent
@@ -52,27 +77,27 @@
     changed_when: false
     register: result
     failed_when: result.status_code != 200
-  
-  - debug: 
-      msg: "{{ result }}" 
+
+  - debug:
+      msg: "{{ result }}"
 
   - name: Unzip the Machine agent file
-    unarchive: 
+    unarchive:
       src:  "{{ machine_agent_dest_folder_linux }}/{{ ma_agent_dest_file }}"
       dest: "{{ machine_agent_dest_folder_linux }}"
       owner: "{{ appdynamics_user }}"
       group: "{{ appdynamics_user }}"
       mode: 0755
-      remote_src: yes 
+      remote_src: yes
     changed_when: false
-   
-  - name: Configure Machine Agent controller-info.xml file 
+
+  - name: Configure Machine Agent controller-info.xml file
     template:
       src: templates/machine-agent-controller-info.xml.j2
-      dest: '{{ machine_agent_dest_folder_linux }}/conf/controller-info.xml' 
+      dest: '{{ machine_agent_dest_folder_linux }}/conf/controller-info.xml'
       owner: "{{ appdynamics_user }}"
       group: "{{ appdynamics_user }}"
-      mode: 0755 
+      mode: 0755
     changed_when: false
 
   - name: Ensure machine agent file is executable
@@ -88,9 +113,9 @@
       src: templates/appdynamics-machine-agent.service.j2
       dest: /etc/systemd/system/appdynamics-machine-agent.service
       force: true
-      owner: root # The Machine Agent must not run as root, you may change it. 
+      owner: root # The Machine Agent must not run as root, you may change it.
       group: root
-      mode: 0644  
+      mode: 0644
     register: machine_agent_systemd_result
 
   - name: Enable the Machine Agent to start at system startup
@@ -99,9 +124,9 @@
       enabled: yes
       force: true # Force it to override existing symlink incase of an upgrade
       masked: no
-  
+
    #Reload systemd if it is an upgrade or re-installation
-  - name:  Reload systemd configs 
+  - name:  Reload systemd configs
     systemd:
       daemon_reload: yes
     when: previous_agent.stat.exists
@@ -119,11 +144,11 @@
     ignore_errors: yes
     changed_when: false
 
-  - name: Show Machine Agent status 
+  - name: Show Machine Agent status
     debug:
       var: result
 
-  - name: Clean up - remove {{ ma_agent_dest_file }} 
+  - name: Clean up - remove {{ ma_agent_dest_file }}
     file:
       path: "{{ machine_agent_dest_folder_linux }}/{{ ma_agent_dest_file }}"
       state: absent


### PR DESCRIPTION
This pull request contains quite a few changes. 
Date:   Thu Nov 19 13:06:59 2020 +0000
    Fixed idempotency on java in windows deploy

Date:   Thu Nov 19 12:31:59 2020 +0000
    added option to set user on java agent

Date:   Wed Nov 18 17:28:57 2020 +0000
    Fixed the agent cleanup to remove the dire and put it back. Also fixed the systemctl script so the command line parameters are applied resulting in the agent name being used.

Date:   Wed Nov 18 17:23:24 2020 +0000
    Changed the "get-agent" script to write to a random temp file to allow multiple instance to run in parallel

Date:   Wed Nov 18 14:03:25 2020 +0000
    Changed the way the agent_type for DB is defined. Rather than setting the os-specific type in the main playbook, it is done internally when working out the agent download URL

Date:   Wed Nov 18 11:34:38 2020 +0000
    Fixed DB agent name setting on windows. Fixed machine agent re-install on Linux (old version was not getting properly deleted)

Date:   Tue Nov 17 13:35:11 2020 +0000
    Added task to install DB agent on windows and optionally install Java using galaxy lean_delivery.java role
