### PR TITLE
Defaults roles

### DIFF
--- a/molecule/dotnet_core/converge.yml
+++ b/molecule/dotnet_core/converge.yml
@@ -23,7 +23,6 @@
     controller_global_analytics_account_name: 'customer1_e52eb4e7-25d2-41c4-a5bc-9685502317f2' # Please add this to your Vault
     controller_host_name: "lncontroller20103-2010-o8evv8rp.appd-cx.com" # Your AppDynamics controller
     controller_account_name: "customer1" # Please add this to your Vault
-    sim_enabled: true
     enable_ssl: false
     controller_port: "8090"
     analytics_event_endpoint: "http://lncontroller20103-2010-o8evv8rp.appd-cx.com:9080"

--- a/molecule/machine/converge.yml
+++ b/molecule/machine/converge.yml
@@ -18,6 +18,7 @@
     controller_global_analytics_account_name: 'customer1_e52eb4e7-25d2-41c4-a5bc-9685502317f2' # Please add this to your Vault 
     controller_host_name: "lncontroller20103-2010-o8evv8rp.appd-cx.com" # Your AppDynamics controller
     controller_account_name: "customer1" # Please add this to your Vault
+    sim_enabled: true
     enable_ssl: false
     controller_port: "8090"
     analytics_event_endpoint: "http://ansible-20100nosshcont-bum4wzwa.appd-cx.com:7001"

--- a/molecule/machine/converge.yml
+++ b/molecule/machine/converge.yml
@@ -18,7 +18,6 @@
     controller_global_analytics_account_name: 'customer1_e52eb4e7-25d2-41c4-a5bc-9685502317f2' # Please add this to your Vault 
     controller_host_name: "lncontroller20103-2010-o8evv8rp.appd-cx.com" # Your AppDynamics controller
     controller_account_name: "customer1" # Please add this to your Vault
-    sim_enabled: true
     enable_ssl: false
     controller_port: "8090"
     analytics_event_endpoint: "http://ansible-20100nosshcont-bum4wzwa.appd-cx.com:7001"

--- a/roles/common/defaults/main.yaml
+++ b/roles/common/defaults/main.yaml
@@ -15,45 +15,9 @@ win_db_finder_string: db-agent-winx64
 linux_ma_finder_string: machineagent-bundle-64bit-linux
 linux_db_finder_string: db-agent
 
-# DB Agent Linux
-db_agent_dest_folder_linux: /opt/appdynamics/db-agent
-db_agent_dest_file: db-agent.zip
-db_agent_name: "AppDynamics"
-
-# DB Agent Windows
-db_agent_dest_folder_windows: C:/appdynamics/db-agent
-
-# Machine Agent Win
-machine_agent_dest_folder_win: C:/appdynamics/machine-agent
-machine_agent_monitor_folder_win: "{{ machine_agent_dest_folder_win }}/monitor"
-temp_dir: /tmp
-
-# Machine Agent Linux
-machine_agent_dest_folder_linux: /opt/appdynamics/machine-agent
-machine_agent_monitor_folder_linux: "{{ machine_agent_dest_folder_linux }}/monitor/"
-
 # Machine Common
 ma_agent_dest_file: machine-agent.zip
 machine_hierarchy: ""
-
-# DotNet Agent Win
-dotnet_agent_dest_folder_win: C:\\appdynamics\\dotnet-agent # '/' does not work with win_package due to msiexec.
-dotnet_agent_dest_file: dotNetAgentSetup64.msi
-
-# Java Agent Linux
-java_agent_dest_folder_linux: /opt/appdynamics/java-agent
-java_agent_dest_file: java-agent.zip
-
-# Java Agent Windows
-java_agent_dest_folder_win: C:/appdynamics/java-agent
-
-# DotNet agent defaults
-monitor_all_IIS_apps: "false"
-runtime_reinstrumentation: "false"
-
-# .NET Core agent Linux
-dotnet_core_agent_dest_folder_linux: /opt/appdynamics/dotnet-core-agent
-dotnet_core_agent_dest_file: dotnet-core-agent.zip
 
 #controller defaults
 enable_ssl: "false"

--- a/roles/common/defaults/main.yaml
+++ b/roles/common/defaults/main.yaml
@@ -22,4 +22,3 @@ machine_hierarchy: ""
 #controller defaults
 enable_ssl: "false"
 enable_proxy: "false"
-sim_enabled: "false"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,7 +20,6 @@
     global_analytics_account_name: "{{ controller_global_analytics_account_name }}"
     controller_host_name: "{{ controller_host_name }}"
     analytics_event_endpoint: "{{ analytics_event_endpoint }}"
-    sim_enabled: "{{ sim_enabled | bool | lower }}"
     enable_ssl: "{{ enable_ssl | bool | lower }}"
     controller_port: "{{ controller_port }}"
     enable_analytics_agent: "{{ enable_analytics_agent | bool | lower }}"

--- a/roles/common/vars/main/controller_vars.yml
+++ b/roles/common/vars/main/controller_vars.yml
@@ -1,6 +1,5 @@
 ---
 analytics_event_endpoint: "https://fra-ana-api.saas.appdynamics.com:443"
-sim_enabled: false
 enable_ssl: false
 controller_port: "443"
 controller_account_name: "customer1"

--- a/roles/db/defaults/main.yml
+++ b/roles/db/defaults/main.yml
@@ -1,0 +1,7 @@
+# DB Agent Linux
+db_agent_dest_folder_linux: /opt/appdynamics/db-agent
+db_agent_dest_file: db-agent.zip
+db_agent_name: "AppDynamics"
+
+# DB Agent Windows
+db_agent_dest_folder_windows: C:/appdynamics/db-agent

--- a/roles/dotnet/defaults/main.yml
+++ b/roles/dotnet/defaults/main.yml
@@ -1,0 +1,7 @@
+# DotNet Agent Win
+dotnet_agent_dest_folder_win: C:\\appdynamics\\dotnet-agent # '/' does not work with win_package due to msiexec.
+dotnet_agent_dest_file: dotNetAgentSetup64.msi
+
+# DotNet agent defaults
+monitor_all_IIS_apps: "false"
+runtime_reinstrumentation: "false"

--- a/roles/dotnet_core/defaults/main.yml
+++ b/roles/dotnet_core/defaults/main.yml
@@ -1,0 +1,3 @@
+# .NET Core agent Linux
+dotnet_core_agent_dest_folder_linux: /opt/appdynamics/dotnet-core-agent
+dotnet_core_agent_dest_file: dotnet-core-agent.zip

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -1,0 +1,6 @@
+# Java Agent Linux
+java_agent_dest_folder_linux: /opt/appdynamics/java-agent
+java_agent_dest_file: java-agent.zip
+
+# Java Agent Windows
+java_agent_dest_folder_win: C:/appdynamics/java-agent

--- a/roles/machine/defaults/main.yml
+++ b/roles/machine/defaults/main.yml
@@ -7,3 +7,5 @@ temp_dir: /tmp
 machine_agent_dest_folder_linux: /opt/appdynamics/machine-agent
 machine_agent_monitor_folder_linux: "{{ machine_agent_dest_folder_linux }}/monitor/"
 
+# Server visibility
+sim_enabled: "false"

--- a/roles/machine/defaults/main.yml
+++ b/roles/machine/defaults/main.yml
@@ -1,0 +1,9 @@
+# Machine Agent Win
+machine_agent_dest_folder_win: C:/appdynamics/machine-agent
+machine_agent_monitor_folder_win: "{{ machine_agent_dest_folder_win }}/monitor"
+temp_dir: /tmp
+
+# Machine Agent Linux
+machine_agent_dest_folder_linux: /opt/appdynamics/machine-agent
+machine_agent_monitor_folder_linux: "{{ machine_agent_dest_folder_linux }}/monitor/"
+


### PR DESCRIPTION
For better isolation, moved defaults to roles when they are used.  Only 'global' vars are kept in common role.