### PR TITLE
Move controller_vars from vars to defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 2021-04-07
+
+### Changed
+
+- Common role: Move controller_vars from vars to defaults
+
 ## 2021-02-24
 
 ### Added

--- a/roles/common/defaults/main.yaml
+++ b/roles/common/defaults/main.yaml
@@ -50,6 +50,11 @@ machine_hierarchy: ""
 enable_ssl: false
 enable_proxy: false
 enable_proxy_authentication: false
+analytics_event_endpoint: "https://fra-ana-api.saas.appdynamics.com:443"
+controller_port: "443"
+controller_account_name: "customer1"
+controller_global_analytics_account_name: "customer1-guid"
+enable_analytics_agent: "true"
 
 #restart_app flag - Set this flag true to automatically restart service
 restart_app: false

--- a/roles/common/vars/main/controller_vars.yml
+++ b/roles/common/vars/main/controller_vars.yml
@@ -1,7 +1,0 @@
----
-analytics_event_endpoint: "https://fra-ana-api.saas.appdynamics.com:443"
-enable_ssl: false
-controller_port: "443"
-controller_account_name: "customer1"
-controller_global_analytics_account_name: "customer1-guid"
-enable_analytics_agent: "true"


### PR DESCRIPTION
This allows controller_port and other input variables to be overriden by inventory vars and not only role vars:
https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#understanding-variable-precedence