### PR TITLE
Enabling Duplicate runs

### DIFF
--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,4 +1,5 @@
 ---
+allow_duplicates: true
 galaxy_info:
   author: Israel Ogbole (https://galaxy.ansible.com/iogbole)
   role_name: common


### PR DESCRIPTION
Required when we are trying to install multiple agents(say java and machine or db and machine) from a single ansible run, because only forcefully rerunning the common role will update the download url using get-agent.sh.

Ref : https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html