### PR TITLE
update refernces to a agent after the log4j issue of December 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This role features:
     - include_role:
         name: appdynamics.agents.java
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         application_name: "IoT_API" # agent default application
         tier_name: "java_tier" # agent default tier
@@ -88,7 +88,7 @@ This role features:
         name: appdynamics.agents.java
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         application_name: "BIGFLY" # agent default application
         tier_name: "java_tier" # agent default tier
@@ -140,7 +140,7 @@ This role features:
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
 
     - include_role:
@@ -169,7 +169,7 @@ In some cases, when application PID user is not local on linux host (i.e. from e
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         # single app mode: Can skip appdynamics user creation and own java-agent directory by app user (wildfly in this case)
         create_appdynamics_user: no
@@ -220,7 +220,7 @@ This role features:
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
 
     - include_role:
@@ -249,7 +249,7 @@ In some cases, when application PID user is not local on linux host (i.e. from e
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         # single app mode: Can skip appdynamics user creation and own java-agent directory by app user (tomcat in this case)
         create_appdynamics_user: no

--- a/molecule/java-jboss/converge.yml
+++ b/molecule/java-jboss/converge.yml
@@ -5,7 +5,7 @@
     - role: appdynamics.agents.java
   vars:
       # Define Agent Type and Version
-      agent_version: 21.1.0
+      agent_version: 21.11.4
       agent_type: sun-java
       agent_log_level: "debug"
       # Your controller details

--- a/molecule/java-tomcat-single-app-mode/converge.yml
+++ b/molecule/java-tomcat-single-app-mode/converge.yml
@@ -5,7 +5,7 @@
     - role: appdynamics.agents.java
   vars:
       # Define Agent Type and Version
-      agent_version: 21.1.0
+      agent_version: 21.11.4
       agent_type: sun-java
 
       agent_log_level: "debug"

--- a/molecule/java-tomcat/converge.yml
+++ b/molecule/java-tomcat/converge.yml
@@ -5,7 +5,7 @@
     - role: appdynamics.agents.java
   vars:
       # Define Agent Type and Version
-      agent_version: 21.1.0
+      agent_version: 21.11.4
       agent_type: sun-java
 
       agent_log_level: "debug"

--- a/playbooks/instrument_jboss.yaml
+++ b/playbooks/instrument_jboss.yaml
@@ -8,7 +8,7 @@
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         #todo remove application, tier_name necessary
         application_name: "IoT_API2"

--- a/roles/instrument_jboss/README.md
+++ b/roles/instrument_jboss/README.md
@@ -20,7 +20,7 @@ Example 1: Install java-agent and instrument one or more applications.
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
 
     - include_role:
@@ -49,7 +49,7 @@ In some cases, when application PID user is not local on linux host (i.e. from e
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         # single app mode: Can skip appdynamics user creation and own java-agent directory by app user (wildfly in this case)
         create_appdynamics_user: no

--- a/roles/instrument_tomcat/README.md
+++ b/roles/instrument_tomcat/README.md
@@ -21,7 +21,7 @@ Example 1: Install java-agent and instrument one or more applications.
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
 
     - include_role:
@@ -50,7 +50,7 @@ In some cases, when application PID user is not local on linux host (i.e. from e
         # use java role variables in the following instrumentation tasks when public: yes
         public: yes
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         # single app mode: Can skip appdynamics user creation and own java-agent directory by app user (tomcat in this case)
         create_appdynamics_user: no

--- a/roles/java/README.md
+++ b/roles/java/README.md
@@ -15,7 +15,7 @@ Example 1: Install java-agent without any apps instrumentation.
     - include_role:
         name: appdynamics.agents.java
       vars:
-        agent_version: 21.1.0
+        agent_version: 21.11.4
         agent_type: java8
         application_name: "IoT_API" # agent default application
         tier_name: "java_tier" # agent default tier


### PR DESCRIPTION
# Remove Refernces to App D Before Log4j

Updated the references in all example files as well as the README.md to versions of AppD after the log4j issue had been fixed.

This should help others avoid reintroducing it by default.